### PR TITLE
#3 Allow to search by "Name" on the product attribute page

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/IProductAttributeService.cs
+++ b/src/Libraries/Nop.Services/Catalog/IProductAttributeService.cs
@@ -24,16 +24,16 @@ public partial interface IProductAttributeService
     /// <returns>A task that represents the asynchronous operation</returns>
     Task DeleteProductAttributesAsync(IList<ProductAttribute> productAttributes);
 
-    /// <summary>
-    /// Gets all product attributes
-    /// </summary>
-    /// <param name="pageIndex">Page index</param>
-    /// <param name="pageSize">Page size</param>
-    /// <returns>
-    /// A task that represents the asynchronous operation
-    /// The task result contains the product attributes
-    /// </returns>
-    Task<IPagedList<ProductAttribute>> GetAllProductAttributesAsync(int pageIndex = 0, int pageSize = int.MaxValue);
+    ///// <summary>
+    ///// Gets all product attributes
+    ///// </summary>
+    ///// <param name="pageIndex">Page index</param>
+    ///// <param name="pageSize">Page size</param>
+    ///// <returns>
+    ///// A task that represents the asynchronous operation
+    ///// The task result contains the product attributes
+    ///// </returns>
+    //Task<IPagedList<ProductAttribute>> GetAllProductAttributesAsync(int pageIndex = 0, int pageSize = int.MaxValue);
 
     /// <summary>
     /// Gets a product attribute 

--- a/src/Libraries/Nop.Services/Catalog/ProductAttributeService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ProductAttributeService.cs
@@ -83,27 +83,27 @@ public partial class ProductAttributeService : IProductAttributeService
             await DeleteProductAttributeAsync(productAttribute);
     }
 
-    /// <summary>
-    /// Gets all product attributes
-    /// </summary>
-    /// <param name="pageIndex">Page index</param>
-    /// <param name="pageSize">Page size</param>
-    /// <returns>
-    /// A task that represents the asynchronous operation
-    /// The task result contains the product attributes
-    /// </returns>
-    public virtual async Task<IPagedList<ProductAttribute>> GetAllProductAttributesAsync(int pageIndex = 0,
-        int pageSize = int.MaxValue)
-    {
-        var productAttributes = await _productAttributeRepository.GetAllPagedAsync(query =>
-        {
-            return from pa in query
-                orderby pa.Name
-                select pa;
-        }, pageIndex, pageSize);
+    ///// <summary>
+    ///// Gets all product attributes
+    ///// </summary>
+    ///// <param name="pageIndex">Page index</param>
+    ///// <param name="pageSize">Page size</param>
+    ///// <returns>
+    ///// A task that represents the asynchronous operation
+    ///// The task result contains the product attributes
+    ///// </returns>
+    //public virtual async Task<IPagedList<ProductAttribute>> GetAllProductAttributesAsync(int pageIndex = 0,
+    //    int pageSize = int.MaxValue)
+    //{
+    //    var productAttributes = await _productAttributeRepository.GetAllPagedAsync(query =>
+    //    {
+    //        return from pa in query
+    //            orderby pa.Name
+    //            select pa;
+    //    }, pageIndex, pageSize);
 
-        return productAttributes;
-    }
+    //    return productAttributes;
+    //}
 
     /// <summary>
     /// Gets a product attribute 

--- a/src/Libraries/Nop.Services/CustomCode/Catalog/IProductAttributeService.cs
+++ b/src/Libraries/Nop.Services/CustomCode/Catalog/IProductAttributeService.cs
@@ -1,0 +1,25 @@
+﻿using Nop.Core;
+using Nop.Core.Domain.Catalog;
+
+namespace Nop.Services.Catalog;
+
+/// <summary>
+/// Product attribute service interface
+/// </summary>
+public partial interface IProductAttributeService
+{
+    #region Product attributes
+
+    /// <summary>
+    /// Gets all product attributes
+    /// </summary>
+    /// <param name="pageIndex">Page index</param>
+    /// <param name="pageSize">Page size</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation
+    /// The task result contains the product attributes
+    /// </returns>
+    Task<IPagedList<ProductAttribute>> GetAllProductAttributesAsync(int pageIndex = 0, int pageSize = int.MaxValue, string name = "");
+
+    #endregion
+}

--- a/src/Libraries/Nop.Services/CustomCode/Catalog/ProductAttributeService.cs
+++ b/src/Libraries/Nop.Services/CustomCode/Catalog/ProductAttributeService.cs
@@ -1,0 +1,41 @@
+﻿using Nop.Core;
+using Nop.Core.Domain.Catalog;
+
+namespace Nop.Services.Catalog;
+
+/// <summary>
+/// Product attribute service
+/// </summary>
+public partial class ProductAttributeService
+{
+    #region Methods
+
+    #region Product attributes
+
+    /// <summary>
+    /// Gets all product attributes
+    /// </summary>
+    /// <param name="pageIndex">Page index</param>
+    /// <param name="pageSize">Page size</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation
+    /// The task result contains the product attributes
+    /// </returns>
+    public virtual async Task<IPagedList<ProductAttribute>> GetAllProductAttributesAsync(int pageIndex = 0,
+        int pageSize = int.MaxValue, string name = "")
+    {
+        var productAttributes = await _productAttributeRepository.GetAllPagedAsync(query =>
+        {
+            return from pa in query
+                   orderby pa.Name
+                   where string.IsNullOrEmpty(name) || pa.Name.Contains(name)
+                   select pa;
+        }, pageIndex, pageSize);
+
+        return productAttributes;
+    }
+
+    #endregion
+
+    #endregion
+}

--- a/src/Presentation/Nop.Web/App_Data/Localization/customResource.nopres.xml
+++ b/src/Presentation/Nop.Web/App_Data/Localization/customResource.nopres.xml
@@ -12,4 +12,10 @@
   <LocaleResource Name="Custom.Checkout.GiftMessage">
     <Value>Gift message</Value>
   </LocaleResource>
+  <LocaleResource Name="Custom.Admin.Catalog.Categories.List.SearchAttributeName">
+    <Value>Attribute name</Value>
+  </LocaleResource>
+  <LocaleResource Name="Custom.Admin.Catalog.Categories.List.SearchAttributeName.Hint">
+    <Value>Search by attribute name</Value>
+  </LocaleResource>
 </Language>

--- a/src/Presentation/Nop.Web/Areas/Admin/CustomCode/Factories/ProductAttributeModelFactory.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/CustomCode/Factories/ProductAttributeModelFactory.cs
@@ -1,0 +1,46 @@
+﻿using Nop.Core.Domain.Catalog;
+using Nop.Services.Catalog;
+using Nop.Services.Localization;
+using Nop.Web.Areas.Admin.Infrastructure.Mapper.Extensions;
+using Nop.Web.Areas.Admin.Models.Catalog;
+using Nop.Web.Framework.Factories;
+using Nop.Web.Framework.Models.Extensions;
+
+namespace Nop.Web.Areas.Admin.Factories;
+
+/// <summary>
+/// Represents the product attribute model factory implementation
+/// </summary>
+public partial class ProductAttributeModelFactory : IProductAttributeModelFactory
+{
+    #region Methods
+
+    /// <summary>
+    /// Prepare paged product attribute list model
+    /// </summary>
+    /// <param name="searchModel">Product attribute search model</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation
+    /// The task result contains the product attribute list model
+    /// </returns>
+    public virtual async Task<ProductAttributeListModel> PrepareProductAttributeListModelAsync(ProductAttributeSearchModel searchModel)
+    {
+        ArgumentNullException.ThrowIfNull(searchModel);
+
+        //get product attributes
+        var productAttributes = await _productAttributeService
+            .GetAllProductAttributesAsync(pageIndex: searchModel.Page - 1, pageSize: searchModel.PageSize, searchModel.SearchAttributeName);
+
+        //prepare list model
+        var model = new ProductAttributeListModel().PrepareToGrid(searchModel, productAttributes, () =>
+        {
+            //fill in model values from the entity
+            return productAttributes.Select(attribute => attribute.ToModel<ProductAttributeModel>());
+
+        });
+
+        return model;
+    }
+
+    #endregion
+}

--- a/src/Presentation/Nop.Web/Areas/Admin/CustomCode/Models/Catalog/ProductAttributeSearchModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/CustomCode/Models/Catalog/ProductAttributeSearchModel.cs
@@ -1,0 +1,16 @@
+﻿using Nop.Web.Framework.Mvc.ModelBinding;
+
+namespace Nop.Web.Areas.Admin.Models.Catalog;
+
+/// <summary>
+/// Represents a product attribute search model
+/// </summary>
+public partial record ProductAttributeSearchModel
+{
+    #region Properties
+
+    [NopResourceDisplayName("Custom.Admin.Catalog.Categories.List.SearchAttributeName")]
+    public string SearchAttributeName { get; set; }
+
+    #endregion
+}

--- a/src/Presentation/Nop.Web/Areas/Admin/Factories/ProductAttributeModelFactory.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Factories/ProductAttributeModelFactory.cs
@@ -103,32 +103,32 @@ public partial class ProductAttributeModelFactory : IProductAttributeModelFactor
         return Task.FromResult(searchModel);
     }
 
-    /// <summary>
-    /// Prepare paged product attribute list model
-    /// </summary>
-    /// <param name="searchModel">Product attribute search model</param>
-    /// <returns>
-    /// A task that represents the asynchronous operation
-    /// The task result contains the product attribute list model
-    /// </returns>
-    public virtual async Task<ProductAttributeListModel> PrepareProductAttributeListModelAsync(ProductAttributeSearchModel searchModel)
-    {
-        ArgumentNullException.ThrowIfNull(searchModel);
+    ///// <summary>
+    ///// Prepare paged product attribute list model
+    ///// </summary>
+    ///// <param name="searchModel">Product attribute search model</param>
+    ///// <returns>
+    ///// A task that represents the asynchronous operation
+    ///// The task result contains the product attribute list model
+    ///// </returns>
+    //public virtual async Task<ProductAttributeListModel> PrepareProductAttributeListModelAsync(ProductAttributeSearchModel searchModel)
+    //{
+    //    ArgumentNullException.ThrowIfNull(searchModel);
 
-        //get product attributes
-        var productAttributes = await _productAttributeService
-            .GetAllProductAttributesAsync(pageIndex: searchModel.Page - 1, pageSize: searchModel.PageSize);
+    //    //get product attributes
+    //    var productAttributes = await _productAttributeService
+    //        .GetAllProductAttributesAsync(pageIndex: searchModel.Page - 1, pageSize: searchModel.PageSize);
 
-        //prepare list model
-        var model = new ProductAttributeListModel().PrepareToGrid(searchModel, productAttributes, () =>
-        {
-            //fill in model values from the entity
-            return productAttributes.Select(attribute => attribute.ToModel<ProductAttributeModel>());
+    //    //prepare list model
+    //    var model = new ProductAttributeListModel().PrepareToGrid(searchModel, productAttributes, () =>
+    //    {
+    //        //fill in model values from the entity
+    //        return productAttributes.Select(attribute => attribute.ToModel<ProductAttributeModel>());
 
-        });
+    //    });
 
-        return model;
-    }
+    //    return model;
+    //}
 
     /// <summary>
     /// Prepare product attribute model

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/ProductAttribute/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/ProductAttribute/List.cshtml
@@ -7,6 +7,10 @@
     NopHtml.SetActiveMenuItemSystemName("Product attributes");
 }
 
+@{
+    const string hideSearchBlockAttributeName = "AttributeListPage.HideSearchBlock";
+    var hideSearchBlock = await genericAttributeService.GetAttributeAsync<bool>(await workContext.GetCurrentCustomerAsync(), hideSearchBlockAttributeName);
+}
 
 <div class="content-header clearfix">
     <h1 class="float-left">
@@ -28,75 +32,124 @@
 
 <section class="content">
     <div class="container-fluid">
-    <div class="cards-group">
-        <div class="card card-default">
-            <div class="card-body">
-                <p>
-                    @T("Admin.Catalog.Attributes.ProductAttributes.Description")
-                    <nop-doc-reference asp-string-resource="@T("Admin.Documentation.Reference.ProductAttributes", Docs.ProductAttributes + Utm.OnAdmin)" asp-add-wrapper="false"/>
-                </p>
-                @await Html.PartialAsync("Table", new DataTablesModel
-                {
-                    Name = "products-grid",
-                    UrlRead = new DataUrl("List", "ProductAttribute", null),
-                    Length = Model.PageSize,
-                    LengthMenu = Model.AvailablePageSizes,
-                    ColumnCollection = new List<ColumnProperty>
-                    {
-                         new ColumnProperty(nameof(ProductAttributeModel.Id))
+        <div class="form-horizontal">
+            <div class="cards-group">
+                    <div class="card card-default card-search">
+                        <div class="card-body">
+                            <div class="row search-row @(!hideSearchBlock ? "opened" : "")" data-hideAttribute="@hideSearchBlockAttributeName">
+                                <div class="search-text">@T("Admin.Common.Search")</div>
+                                <div class="icon-search"><i class="fas fa-magnifying-glass" aria-hidden="true"></i></div>
+                                <div class="icon-collapse"><i class="far fa-angle-@(!hideSearchBlock ? "up" : "down")" aria-hidden="true"></i></div>
+                            </div>
+                            <div class="search-body @(hideSearchBlock ? "closed" : "")">
+                                <div class="row">
+                                    <div class="col-md-5">
+                                        <div class="form-group row">
+                                            <div class="col-md-4">
+                                                <nop-label asp-for="SearchAttributeName" />
+                                            </div>
+                                            <div class="col-md-8">
+                                                <nop-editor asp-for="SearchAttributeName" />
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="row">
+                                        <div class="text-center col-12">
+                                            <button type="button" id="search-products-att" class="btn btn-primary btn-search">
+                                                <i class="fas fa-magnifying-glass"></i>
+                                                @T("Admin.Common.Search")
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                <div class="card card-default">
+                    <div class="card-body">
+                        <p>
+                            @T("Admin.Catalog.Attributes.ProductAttributes.Description")
+                            <nop-doc-reference asp-string-resource="@T("Admin.Documentation.Reference.ProductAttributes", Docs.ProductAttributes + Utm.OnAdmin)" asp-add-wrapper="false"/>
+                        </p>
+                      
+                        @await Html.PartialAsync("Table", new DataTablesModel
                         {
-                            IsMasterCheckBox = true,
-                            Render = new RenderCheckBox("checkbox_productattributes"),
-                            ClassName =  NopColumnClassDefaults.CenterAll,
-                            Width = "50"
-                        },
-                        new ColumnProperty(nameof(ProductAttributeModel.Name))
-                        {
-                            Title = T("Admin.Catalog.Attributes.ProductAttributes.Fields.Name").Text
-                        },
-                        new ColumnProperty(nameof(ProductAttributeModel.Id))
-                        {
-                            Title = T("Admin.Common.Edit").Text,
-                            Width = "100",
-                            ClassName =  NopColumnClassDefaults.Button,
-                            Render = new RenderButtonEdit(new DataUrl("~/Admin/ProductAttribute/Edit"))
-                        }
-                    }
-                })
-
-                <script>
-                    $(function() {
-                        $('#delete-selected-action-confirmation-submit-button').bind('click', function () {
-                            var postData = {
-                                selectedIds: selectedIds
-                            };
-                            addAntiForgeryToken(postData);
-                            $.ajax({
-                                cache: false,
-                                type: "POST",
-                                url: "@(Url.Action("DeleteSelected", "ProductAttribute"))",
-                                data: postData,
-                                error: function (jqXHR, textStatus, errorThrown) {
-                                    showAlert('deleteSelectedFailed', errorThrown);
+                            Name = "products-grid",
+                            UrlRead = new DataUrl("List", "ProductAttribute", null),
+                            SearchButtonId = "search-products-att",
+                            Length = Model.PageSize,
+                            LengthMenu = Model.AvailablePageSizes,
+                            Filters = new List<FilterParameter>
+                            {
+                                new FilterParameter(nameof(Model.SearchAttributeName))
+                            },
+                            ColumnCollection = new List<ColumnProperty>
+                            {
+                                 new ColumnProperty(nameof(ProductAttributeModel.Id))
+                                {
+                                    IsMasterCheckBox = true,
+                                    Render = new RenderCheckBox("checkbox_productattributes"),
+                                    ClassName =  NopColumnClassDefaults.CenterAll,
+                                    Width = "50"
                                 },
-                                complete: function (jqXHR, textStatus) {
-                                    if (jqXHR.status === 204)
-                                    {
-                                        showAlert('nothingSelectedAlert', '@T("Admin.Common.Alert.NothingSelected")');
-                                        return;
-                                    }
-                                    updateTable('#products-grid');
+                                new ColumnProperty(nameof(ProductAttributeModel.Name))
+                                {
+                                    Title = T("Admin.Catalog.Attributes.ProductAttributes.Fields.Name").Text
+                                },
+                                new ColumnProperty(nameof(ProductAttributeModel.Id))
+                                {
+                                    Title = T("Admin.Common.Edit").Text,
+                                    Width = "100",
+                                    ClassName =  NopColumnClassDefaults.Button,
+                                    Render = new RenderButtonEdit(new DataUrl("~/Admin/ProductAttribute/Edit"))
                                 }
+                            }
+                        })
+
+                        <script>
+                            $(function() {
+                                $('#delete-selected-action-confirmation-submit-button').bind('click', function () {
+                                    var postData = {
+                                        selectedIds: selectedIds
+                                    };
+                                    addAntiForgeryToken(postData);
+                                    $.ajax({
+                                        cache: false,
+                                        type: "POST",
+                                        url: "@(Url.Action("DeleteSelected", "ProductAttribute"))",
+                                        data: postData,
+                                        error: function (jqXHR, textStatus, errorThrown) {
+                                            showAlert('deleteSelectedFailed', errorThrown);
+                                        },
+                                        complete: function (jqXHR, textStatus) {
+                                            if (jqXHR.status === 204)
+                                            {
+                                                showAlert('nothingSelectedAlert', '@T("Admin.Common.Alert.NothingSelected")');
+                                                return;
+                                            }
+                                            updateTable('#products-grid');
+                                        }
+                                    });
+                                    $('#delete-selected-action-confirmation').modal('toggle');
+                                    return false;
+                                });
                             });
-                            $('#delete-selected-action-confirmation').modal('toggle');
-                            return false;
-                        });
-                    });
-                </script>
-                <nop-alert asp-alert-id="deleteSelectedFailed" />
-                <nop-alert asp-alert-id="nothingSelectedAlert" />
+                        </script>
+                        <script>
+                            $(function() {
+                                $("#@Html.IdFor(model => model.SearchAttributeName)").keydown(function (event) {
+                                    if (event.keyCode === 13) {
+                                        $("#search-products-att").trigger("click");
+                                        return false;
+                                    }
+                                });
+                            });
+                        </script>
+                        <nop-alert asp-alert-id="deleteSelectedFailed" />
+                        <nop-alert asp-alert-id="nothingSelectedAlert" />
+                    </div>
+                </div>
             </div>
         </div>
     </div>
-</div>
 </section>


### PR DESCRIPTION
3. Allow to search by "Name" on the product attribute page (admin area)

- Extended ProductAttributeSearchModel and added SearchAttributeName
- Added Search panel in ProductAttribute/List page & added support for filter in grid listing
- Modified GetAllProductAttributesAsync service and added optional param "name" & added logic to search by name
- Utilized it in PrepareProductAttributeListModelAsync factory